### PR TITLE
Add routing capabilities to the nested workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,35 @@ Yes, you can! 💡
 ### What is the final result?
    The final result should be similar to what you see in the screenshot below. Notice the logs path. Also, notice the the nested lab vCenter IP address (i.e., 10.1.1.2), because GroupNumber was set to 1 and NumberOfNestedLabs was set to 1. ![screenshot](images/final-screenshot.png)
 
+## No System Assigned Managed Identity
+
+In case you cannot deploy a System Assigned Managed Identity on the Jump server used to deploy resources, follow the follwing process:
+
+   1) From Jumpbox VM, open Command Prompt (cmd.exe).
+   2) Change directory to C:\Temp by running:
+```powershell
+cd c:\Temp\
+```
+   3) Create file `C:\Temp\nestedlabs.yaml` with the following content and replace the values with the ones matching your environment:
+
+```yaml
+AVSvCenter:
+  URL: "X.Y.Z.2" # Please enter the URL for AVS vCenter, do not include https:// or any slashes
+  Username: "cloudadmin@vsphere.local" # AVS vCenter Username, should be consistent
+  Password: "passwordvalue" #Enter the password for the cloudadmin@vsphere.local
+AVSNSXT:
+  Host: "X.Y.Z.3" # Please enter the URL for AVS NSX-T Manager, do not include https:// or any slashes
+  Username: "cloudadmin" # NSX-T Username from the Azure portal
+  Password: "passwordvalue" # #Enter the password for the cloudadmin
+```
+   4) Validate that **bootstrap.ps1** exits and the file extension is **.ps1** not .txt for example
+   5) Run this command, but first make sure you setup the appropriate **GroupNumber** (keep it 1 if you are not sure), and required number of nested lab environments: **NumberOfNestedLabs**. 
+      > [!NOTE]
+      > If you are using **Azure Government**, please add **-IsAzureGovernment** switch parameter to the command
+      ```powershell
+      powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -GroupNumber 1 -NumberOfNestedLabs 1
+      ```
+
 ## Troubleshoot
 
 ### How to delete nested labs?
@@ -169,6 +198,33 @@ You may want to clean nested labs as they could have already consumed and you wo
 
 5) Go to NSX-T Portal -> Go to Segments.
 6) Delete any segments created for the NestedLabs (i.e.: Group-1-1-**NestedLab**).
+
+### Deploy out of a ScheduledTask context
+
+You can run `bootstrap.ps1` with parameter `-NoAuto` to initiate a deployement that will not use a ScheduleTask nor reboot the Jumbox.
+
+```powershell
+powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -NoAuto
+```
+
+You can then Open a PowerShell 7 session to run the deployement script:
+
+```powershell
+C:\Program Files\PowerShell\7\pwsh.exe -ExecutionPolicy Unrestricted -File c:\temp\bootstrap-nestedlabs.ps1 -GroupId X -Labs Y
+```
+
+
+### Restart a deployment from a specific lab index
+
+In case of failure during the labs deployment, you can restart the deployment process from a specific lab index by using `bootstrap-nestedlabs.ps1` and parameter `-ReStartIndex X`.
+
+> [!NOTE]
+> You will need to use the clean up process from above to remove existing data from the labs you want to retry the creation if some resources where already deployed.
+
+```powershell
+# if you need to (re)deploy lab 5 to 6 only:
+c:\temp\bootstrap-nestedlabs.ps1 -GroupId X -Labs 6 -ReStartIndex 5
+```
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Yes, you can! 💡
       > [!NOTE]
       > If you are using **Azure Government**, please add **-IsAzureGovernment** switch parameter to the command
       ```powershell
-      powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -GroupNumber 1 -NumberOfNestedLabs 1
+      powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -GroupNumber 1 -NumberOfNestedLabs 1 -automated
       ```
 
    5) You can track progress by keeping an eye on **bootstrap.log** and **bootstrap-nestedlabs.log** which will be created in **C:\Temp** directory.
@@ -161,11 +161,11 @@ cd c:\Temp\
 
 ```yaml
 AVSvCenter:
-  URL: "X.Y.Z.2" # Please enter the URL for AVS vCenter, do not include https:// or any slashes
+  IP: "X.Y.Z.2" # Please enter the URL for AVS vCenter, do not include https:// or any slashes
   Username: "cloudadmin@vsphere.local" # AVS vCenter Username, should be consistent
   Password: "passwordvalue" #Enter the password for the cloudadmin@vsphere.local
 AVSNSXT:
-  Host: "X.Y.Z.3" # Please enter the URL for AVS NSX-T Manager, do not include https:// or any slashes
+  IP: "X.Y.Z.3" # Please enter the URL for AVS NSX-T Manager, do not include https:// or any slashes
   Username: "cloudadmin" # NSX-T Username from the Azure portal
   Password: "passwordvalue" # #Enter the password for the cloudadmin
 ```
@@ -174,7 +174,7 @@ AVSNSXT:
       > [!NOTE]
       > If you are using **Azure Government**, please add **-IsAzureGovernment** switch parameter to the command
       ```powershell
-      powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -GroupNumber 1 -NumberOfNestedLabs 1
+      powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -GroupNumber 1 -NumberOfNestedLabs 1 -automated
       ```
 
 ## Troubleshoot
@@ -201,10 +201,10 @@ You may want to clean nested labs as they could have already consumed and you wo
 
 ### Deploy out of a ScheduledTask context
 
-You can run `bootstrap.ps1` with parameter `-NoAuto` to initiate a deployement that will not use a ScheduleTask nor reboot the Jumbox.
+You can run `bootstrap.ps1` without parameter `-automated` to initiate a deployement that will not use a ScheduleTask nor reboot the Jumbox.
 
 ```powershell
-powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1 -NoAuto
+powershell.exe -ExecutionPolicy Unrestricted -File bootstrap.ps1
 ```
 
 You can then Open a PowerShell 7 session to run the deployement script:

--- a/scripts/bootstrap-nestedlabs.ps1
+++ b/scripts/bootstrap-nestedlabs.ps1
@@ -1,24 +1,34 @@
 param (
     [Parameter()]
+    # Description: "Group number for the set of nested labs to deploy. Default is 1."
     [ValidateRange(1, 64)]
     [Alias("GroupId")]
     [Int] $GroupNumber = 1,
 
     [Parameter()]
+    # Description: "Number of nested labs to be deployed. Default is 4."
     [ValidateRange(1, 32)]
     [Alias("Labs")]
     [Int] $NumberOfNestedLabs = 4,
 
     [Parameter()]
+    # Description: "Is Azure Government Cloud? Default is false."
     [Alias("IsAzureGovernment")] 
-    [switch] $isMAG = $false
+    [switch] $isMAG = $false,
+
+    [Parameter()]
+    # Description: "Restart build sequence from this index. Default is 1."
+    [Int] $ReStartIndex = 1
 )
 
 # constant variables
 $Logfile = "C:\temp\bootstrap-nestedlabs.log"
 $TempPath = "C:\temp"
+$ConfigurationFile = "C:\temp\nestedlabs.yml"
 $ExtractionPath = "C:\temp\avs-embedded-labs-auto"
 $NestedLabScriptURL = "https://raw.githubusercontent.com/Azure/avslabs/main/scripts/labdeploy.ps1"
+$UbuntuOvaURL = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.ova"
+$RouterUserDataURL = "https://raw.githubusercontent.com/Azure/avslabs/main/scripts/router-userdata.yaml"
 
 # initializing
 
@@ -177,7 +187,7 @@ function Set-NestedLabRequirement {
     # Start-Sleep -Seconds 30
 
     # Install YAML PowerShell Module
-    # $result = (Get-Module -ListAvailable -Name powershell-yaml) ? $true : (Install-Module powershell-yaml -Scope AllUsers -Force -SkipPublisherCheck -AllowClobber -ErrorAction Ignore)
+    $result = (Get-Module -ListAvailable -Name powershell-yaml) ? $true : (Install-Module powershell-yaml -Scope AllUsers -Force -SkipPublisherCheck -AllowClobber -ErrorAction Ignore)
 
     # Extra Verification 
     $result = (Get-Module -ListAvailable -Name VMware.PowerCLI) ? $true : $false
@@ -192,34 +202,46 @@ function Set-NestedLabPackage {
     
     if (Test-Path $ExtractionPath -PathType Container) {
         Write-Log "|--Set-NestedLabPackage - Directory already exists"
-        return $true
-    }
-
-    if (Test-Path $ZipPath -PathType Leaf) {
+    } else {
+        if (Test-Path $ZipPath -PathType Leaf) {
         
-        Set-Location $TempPath
+            Set-Location $TempPath
 
-        #Checking if there is enough diskspace before extracting the file
-        if (Test-AvailableDiskSpace) {
-            #Extracting Lab Package (zip) using 7zip
-            Write-Log "|--Set-NestedLabPackage - Extracting '$ZipPath'"
-            7z x $ZipPath -o*
+            #Checking if there is enough diskspace before extracting the file
+            if (Test-AvailableDiskSpace) {
+                #Extracting Lab Package (zip) using 7zip
+                Write-Log "|--Set-NestedLabPackage - Extracting '$ZipPath'"
+                7z x $ZipPath -o*
+            }
+
+            #Downloading latest version of labdeploy.ps1
+            $NestedLabScriptPath = $ExtractionPath + "\" + $NestedLabScriptURL.Split('/')[-1]
+            if (Test-Path $NestedLabScriptPath -PathType Leaf) {
+                Remove-Item -Path $NestedLabScriptPath -Force -Confirm:$false -ErrorAction Continue
+            }
+
+            Start-BitsTransfer -Source $NestedLabScriptURL -Destination $ExtractionPath -Priority High
         }
-
-        #Downloading latest version of labdeploy.ps1
-        $NestedLabScriptPath = $ExtractionPath + "\" + $NestedLabScriptURL.Split('/')[-1]
-        if (Test-Path $NestedLabScriptPath -PathType Leaf) {
-            Remove-Item -Path $NestedLabScriptPath -Force -Confirm:$false -ErrorAction Continue
+        else {
+            return $false
         }
-
-        Start-BitsTransfer -Source $NestedLabScriptURL -Destination $ExtractionPath -Priority High
-
-        return (Test-Path $ExtractionPath)
-    }
-    else {
-        return $false
     }
 
+    $UbuntuOvaPath = $ExtractionPath + "\Templates\" + $UbuntuOvaURL.Split('/')[-1]
+    if (Test-Path $UbuntuOvaPath -PathType Leaf) {
+        Write-Log "|--Set-NestedLabPackage - Ubuntu image already downloaded"
+    } else {
+        Start-BitsTransfer -Source $UbuntuOvaURL -Destination "$ExtractionPath\Templates\" -Priority High
+    }
+
+    $RouterUserDataPath = $ExtractionPath + "\" + $RouterUserDataURL.Split('/')[-1]
+    if (Test-Path $RouterUserDataPath -PathType Leaf) {
+        Write-Log "|--Set-NestedLabPackage - Router userdata file already downloaded"
+    } else {
+        Start-BitsTransfer -Source $RouterUserDataURL -Destination $ExtractionPath -Priority High
+    }
+    
+    return (Test-Path $ExtractionPath)
 }
 
 
@@ -341,7 +363,7 @@ function Build-NestedLab {
 
     Write-Log "|--Build-NestedLab - Started deploying $NumberOfNestedLabs nested labs for GroupID $GroupNumber"
 
-    for ($i = 1; $i -le $NumberOfNestedLabs; $i++) {
+    for ($i = $ReStartIndex; $i -le $NumberOfNestedLabs; $i++) {
         #Start-Process -Wait -FilePath PWSH.exe -WorkingDirectory $ExtractionPath -ArgumentList "-ExecutionPolicy Unrestricted -NonInteractive -NoProfile -WindowStyle Hidden", "-Command .\labdeploy.ps1 -group $groupNumber -lab $i -automated"
         Write-Log "|--Build-NestedLab - Started building Nested Lab #$i "
         .\labdeploy.ps1 -group $GroupNumber -lab $i -automated -AVSInfo $AVSInfo
@@ -354,7 +376,15 @@ function Build-NestedLab {
 }
 
 function Complete-NestedLabDeployment {
-    Disable-ScheduledTask -TaskName "Build Nested Labs"
+    $task = Get-ScheduledTask -TaskName "Build Nested Labs" -ErrorAction SilentlyContinue
+    if ($null -eq $task) {
+        Write-Log "|--Complete-NestedLabDeployment - No Windows Scheduled Task to disable"
+        return
+    }
+    if ($task.State -eq "Ready") {
+        Write-Log "|--Complete-NestedLabDeployment - Disabling Windows Scheduled Task"
+        Disable-ScheduledTask -TaskName "Build Nested Labs"
+    }
 }
 
 #-------------------------------------------------------------------------------------------------------#
@@ -374,20 +404,30 @@ Write-Log "Setting basic requirements for labdeploy.ps1 script (i.e.: installing
 if (Set-NestedLabRequirement) {
     Write-Log "Extracting nested labs Zip package"
     if (Set-NestedLabPackage) {
-        Write-Log "Validation authentication to AVS from Jumpbox VM (i.e.: making sure Jumpbox VM managed identity has contributor permission over AVS Private Cloud resource)"
-        if (Test-AuthenticationToAVS) {
-            Write-Log "Getting AVS credentials information that is required by labdeploy.ps1 script"
-            $AVSInfo = Get-NestedLabConfigurations
-            if ($AVSInfo.Count -eq 2) {
-                Write-Log "Checking if AVS provisioning state is 'Succeeded' (i.e. making sure AVS is ready for next steps)"
-                if (Test-AVSReadiness) {
-                    Write-Log "Enabling outbound Internet access from AVS which is required by labdeploy.ps1 script"
-                    if (Enable-AVSPrivateCloudInternetViaSNAT) {
-                        Write-Log "Executing labdeploy.ps1 script for building $NumberOfNestedLabs nested VMware vSphere labs inside AVS Private Cloud"
-                        Build-NestedLab -GroupNumber $GroupNumber -NumberOfNestedLabs $NumberOfNestedLabs -AVSInfo $AVSInfo
+        if (-not(Test-Path $ConfigurationFile)) {
+            Write-Log "Validation authentication to AVS from Jumpbox VM (i.e.: making sure Jumpbox VM managed identity has contributor permission over AVS Private Cloud resource)"
+            if (Test-AuthenticationToAVS) {
+                Write-Log "Getting AVS credentials information that is required by labdeploy.ps1 script"
+                $AVSInfo = Get-NestedLabConfigurations
+                if ($AVSInfo.Count -eq 2) {
+                    Write-Log "Checking if AVS provisioning state is 'Succeeded' (i.e. making sure AVS is ready for next steps)"
+                    if (Test-AVSReadiness) {
+                        Write-Log "Enabling outbound Internet access from AVS which is required by labdeploy.ps1 script"
+                        if (Enable-AVSPrivateCloudInternetViaSNAT) {
+                            Write-Log "Executing labdeploy.ps1 script for building $NumberOfNestedLabs nested VMware vSphere labs inside AVS Private Cloud"
+                            Build-NestedLab -GroupNumber $GroupNumber -NumberOfNestedLabs $NumberOfNestedLabs -AVSInfo $AVSInfo
+                        }
                     }
                 }
             }
+        } else {
+            Write-Log "Building labs without using the System Assigned Managed Identity"
+            if (Test-Path "$TempPath/nestedlabs.yml" -PathType Leaf) {
+                Copy-Item "$TempPath/nestedlabs.yml" "$ExtractionPath/nestedlabs.yml"
+            } else {
+                Write-Log "Missing file $TempPath/nestedlabs.yml to build labs without System Assigned Managed Identity"
+            }
+            Build-NestedLab -GroupNumber $GroupNumber -NumberOfNestedLabs $NumberOfNestedLabs
         }
     }
 }

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -14,8 +14,8 @@ param (
     [switch] $isMAG = $false,
 
     [Parameter()]
-    [Alias("NotAutomated")] 
-    [switch] $NoAuto = $false
+    [Alias("IsAutomated")] 
+    [switch] $automated = $false
 )
 
 # constant variables
@@ -191,14 +191,14 @@ Write-Log "Downloading bootstrap-nestedlabs.ps1 script"
 Get-BootstrapScript
 
 # if automated
-if (-Not($IsAuto)) {
+if ($automated) {
     Write-Log "Creating a Windows Scheduled Task to register bootstrap-nestedlabs.ps1 script, and trigger it on Jumpbox VM startup"
     Set-BootstrapScheduledTask
 }
 
 Write-Log "Downloading nested labs Zip package"
 $retNestedLabPackage=Get-NestedLabPackage
-if (-Not($NoAuto) -and $retNestedLabPackage) {
+if ($automated -and $retNestedLabPackage) {
     Write-Log "Rebooting Jumpbox VM"
     Set-Jumpbox
 } else {

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -11,7 +11,11 @@ param (
 
     [Parameter()]
     [Alias("IsAzureGovernment")] 
-    [switch] $isMAG = $false
+    [switch] $isMAG = $false,
+
+    [Parameter()]
+    [Alias("NotAutomated")] 
+    [switch] $NoAuto = $false
 )
 
 # constant variables
@@ -40,6 +44,9 @@ function Write-Log {
     $timeStamp = (Get-Date).toString("yyyy/MM/dd HH:mm:ss")
     $logMessage = "[$timeStamp] $message"
     Add-content $LogFile -value $LogMessage
+    if (-not($IsAuto)) {
+        Write-Host $logMessage
+    }
 }
 
 function Test-TempDirectory {
@@ -65,11 +72,11 @@ function Install-Applications {
 
     Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-    choco install powershell-core -y
-    choco install azcopy10 -y
-    choco install azure-cli -y
-    choco install 7zip -y
-    choco install VMRC -y
+    choco install powershell-core   -y -WarningAction SilentlyContinue
+    choco install azcopy10          -y -WarningAction SilentlyContinue
+    choco install azure-cli         -y -WarningAction SilentlyContinue
+    choco install 7zip              -y -WarningAction SilentlyContinue
+    choco install VMRC              -y -WarningAction SilentlyContinue
 
     #Optional
     #choco install vscode -y
@@ -183,13 +190,20 @@ Test-TempDirectory
 Write-Log "Downloading bootstrap-nestedlabs.ps1 script"
 Get-BootstrapScript
 
-Write-Log "Creating a Windows Scheduled Task to register bootstrap-nestedlabs.ps1 script, and trigger it on Jumpbox VM startup"
-Set-BootstrapScheduledTask
+# if automated
+if (-Not($IsAuto)) {
+    Write-Log "Creating a Windows Scheduled Task to register bootstrap-nestedlabs.ps1 script, and trigger it on Jumpbox VM startup"
+    Set-BootstrapScheduledTask
+}
 
 Write-Log "Downloading nested labs Zip package"
-if (Get-NestedLabPackage) {
+$retNestedLabPackage=Get-NestedLabPackage
+if (-Not($NoAuto) -and $retNestedLabPackage) {
     Write-Log "Rebooting Jumpbox VM"
     Set-Jumpbox
+} else {
+    Write-Host "Lab preparation is not in full automated mode. Next step:"
+    Write-Host "  powershell.exe -ExecutionPolicy Unrestricted -File c:\temp\bootstrap-nestedlabs.ps1 -GroupId X -Labs Y"
 }
 
 Write-Log "Concluding Execution"

--- a/scripts/nestedlabs.yml
+++ b/scripts/nestedlabs.yml
@@ -1,8 +1,8 @@
 AVSvCenter:
-  URL: "X.Y.Z.2" # Please enter the URL for AVS vCenter, do not include https:// or any slashes
+  IP: "X.Y.Z.2" # Please enter the URL for AVS vCenter, do not include https:// or any slashes
   Username: "cloudadmin@vsphere.local" # AVS vCenter Username, should be consistent
   Password: "passwordvalue" #Enter the password for the cloudadmin@vsphere.local
 AVSNSXT:
-  Host: "X.Y.Z.3" # Please enter the URL for AVS NSX-T Manager, do not include https:// or any slashes
+  IP: "X.Y.Z.3" # Please enter the URL for AVS NSX-T Manager, do not include https:// or any slashes
   Username: "cloudadmin" # NSX-T Username from the Azure portal
   Password: "passwordvalue" # #Enter the password for the cloudadmin

--- a/scripts/router-userdata.yaml
+++ b/scripts/router-userdata.yaml
@@ -1,0 +1,42 @@
+#cloud-config
+hostname: router
+package_update: true
+package_upgrade: true
+
+write_files:
+- content: |
+    network:
+      ethernets:
+        ens192:
+          dhcp6: false
+          dhcp4: false
+          addresses: [ __PRIMARY_IPADDRESS__/__PRIMARY_NETMASK__ ]
+          routes:
+          - to: default
+            via: __PRIMARY_GATEWAY__
+          nameservers:
+            addresses: [ 1.1.1.1 ]
+        ens224:
+          dhcp6: false
+          dhcp4: false
+          addresses: [ __SECONDIP_ADDRESS__/__SECONDARY_NETMASK__ ]
+  path: /etc/netplan/50-cloud-init.yaml
+  append: false
+
+chpasswd:
+  list: |
+    root:MSFTavs1!
+    ubuntu:MSFTavs1!
+  expire: false
+
+runcmd:
+# SSH with password
+- sed 's/PasswordAuthentication no/PasswordAuthentication yes/' -i /etc/ssh/sshd_config
+- systemctl restart sshd
+# Network setup
+- netplan apply
+# Routing capabilities
+- echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+- sysctl -p
+- iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+- iptables-save >/etc/systemd/scripts/ip4save


### PR DESCRIPTION
* Add routing capabilities to the nested workload by deploying a router VM
  * Enable to test HCX networking including MON
* Add a way to build labs without using the System Assigned Managed Identity
  * Scripts will use a user-customized yaml configuration file to get IP, users and passwords
  * Readme was updated to match this deployement method
* Cleanup of some unused code and comments